### PR TITLE
Clean up logging, add --debug and --quiet options

### DIFF
--- a/pds_github_util/assets/assets.py
+++ b/pds_github_util/assets/assets.py
@@ -3,7 +3,6 @@ import os
 
 from zipfile import ZipFile
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -45,7 +44,7 @@ def zip_assets(file_paths, outzip):
     if not os.path.exists(os.path.dirname(outzip)):
         os.makedirs(os.path.dirname(outzip))
 
-    logger.info(f'zipping assets')
+    logger.info('zipping assets')
     with ZipFile(outzip,'w') as z:
         for f in file_paths: 
             z.write(f, os.path.basename(f))

--- a/pds_github_util/branches/git_actions.py
+++ b/pds_github_util/branches/git_actions.py
@@ -5,7 +5,6 @@ import re
 from git import Repo
 import github3
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/pds_github_util/branches/git_ping.py
+++ b/pds_github_util/branches/git_ping.py
@@ -1,4 +1,4 @@
-import argparse
+import argparse, logging
 from pds_github_util.branches.git_actions import ping_repo_branch
 from pds_github_util.utils import addStandardArguments
 
@@ -15,7 +15,8 @@ def main():
     parser.add_argument('--message', dest='message',
                         help='commit message')
     args = parser.parse_args()
-
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
+    
     # read organization and repository name
     ping_repo_branch(args.repo, args.branch, args.message, token=args.token)
 

--- a/pds_github_util/corral/cattle_head.py
+++ b/pds_github_util/corral/cattle_head.py
@@ -4,12 +4,10 @@ from bs4 import BeautifulSoup
 import github3
 from packaging import version
 from datetime import datetime
-logging.basicConfig(level=logging.INFO)
 
 import http.client
 http.client.HTTPConnection.debuglevel = 1
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 requests_log = logging.getLogger("requests.packages.urllib3")

--- a/pds_github_util/corral/herd.py
+++ b/pds_github_util/corral/herd.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import logging
 from pds_github_util.corral import CattleHead
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/pds_github_util/gh_pages/build_summaries.py
+++ b/pds_github_util/gh_pages/build_summaries.py
@@ -12,15 +12,11 @@ from pds_github_util.utils.tokens import GITHUB_TOKEN
 from pds_github_util.utils import addStandardArguments
 
 
-logger = logging.getLogger('github3')
-logger.setLevel(level=logging.WARNING)
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger()
+_logger = logging.getLogger(__name__)
 
 
 def copy_resources():
-    logger.info("write static resources (img, config)...")
+    _logger.info("write static resources (img, config)...")
     resources = resource_filename(__name__, 'resources')
     for f in os.listdir(resources):
         i_p = os.path.join(resources, f)
@@ -33,7 +29,6 @@ def copy_resources():
             if os.path.exists(o_p):
                 os.remove(o_p)
             copy(i_p, os.getcwd())
-
 
 
 def build_summaries(token, path=os.getcwd(), format='md', version_pattern=None):
@@ -55,7 +50,7 @@ def build_summaries(token, path=os.getcwd(), format='md', version_pattern=None):
             token=token,
             local_git_tmp_dir='/tmp'))
         herds.append(herd)
-        version_pattern = '[0-9]+\.[0-9]+'
+        version_pattern = r'[0-9]+\.[0-9]+'
 
     # loop on selected version patterns
     for herd in loop_checkout_on_branch(
@@ -84,10 +79,11 @@ def main():
     parser.add_argument('--format', dest='format', default='rst',
                         help='format of the summary, accepted formats are md and rst')
     args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
 
     token = args.token or GITHUB_TOKEN
     if not token:
-        logger.error(f'Github token must be provided or set as environment variable (GITHUB_TOKEN).')
+        _logger.error('Github token must be provided or set as environment variable (GITHUB_TOKEN).')
         sys.exit(1)
 
     build_summaries(token, args.path, args.format)
@@ -95,4 +91,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/pds_github_util/gh_pages/root_index.py
+++ b/pds_github_util/gh_pages/root_index.py
@@ -41,7 +41,7 @@ class HerdTable:
 def update_index(root_dir, herds, format='md'):
 
     index_file_name = os.path.join(root_dir, 'index.md')
-    index_md_file = mdutils.MdUtils(file_name=index_file_name, title=f'PDS Engineering Node software suite, builds')
+    index_md_file = mdutils.MdUtils(file_name=index_file_name, title='PDS Engineering Node software suite, builds')
 
     herds.sort(key=lambda x: x.get_release_datetime(), reverse=True)
     herds_iterator = iter(herds)

--- a/pds_github_util/gh_pages/summary.py
+++ b/pds_github_util/gh_pages/summary.py
@@ -4,7 +4,6 @@ from pds_github_util.tags.tags import Tags
 from pds_github_util.utils import RstClothReferenceable
 from pds_github_util.corral.herd import Herd
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 COLUMNS = ['manual', 'changelog', 'requirements', 'download', 'license', 'feedback']

--- a/pds_github_util/issues/RstRddReport.py
+++ b/pds_github_util/issues/RstRddReport.py
@@ -25,6 +25,7 @@ class PDSIssue(ShortIssue):
 
 from pds_github_util.issues.utils import get_issue_priority, ignore_issue
 
+
 class RddReport:
 
     ISSUE_TYPES = ['bug', 'enhancement', 'requirement', 'theme']
@@ -51,11 +52,12 @@ class RddReport:
                  build=None,
                  token=None):
 
-        # Quiet github3 logging
+        # Quiet github3 logging — 😬 This should be user-controllable (command-line, config file) and not
+        # forced by the code.
         self._logger = logging.getLogger('github3')
         self._logger.setLevel(level=logging.WARNING)
 
-        logging.basicConfig(level=logging.INFO)
+        # Why bother saving the github3 logger in ``_logger`` if we're just overwriting it with the ``_name`` logger? 🤔
         self._logger = logging.getLogger(__name__)
 
         self._org = org

--- a/pds_github_util/issues/issues.py
+++ b/pds_github_util/issues/issues.py
@@ -7,7 +7,7 @@ import logging
 
 
 from mdutils.mdutils import MdUtils
-from pds_github_util.issues.utils import TOP_PRIORITIES, get_issue_type, get_issue_priority, ignore_issue, get_issues_groupby_type, is_theme
+from pds_github_util.issues.utils import TOP_PRIORITIES, get_issue_priority, get_issues_groupby_type
 
 from pds_github_util.utils import GithubConnection, addStandardArguments
 from pds_github_util.issues import RstRddReport
@@ -16,12 +16,7 @@ from pds_github_util.issues import MetricsRddReport
 
 DEFAULT_GITHUB_ORG = 'NASA-PDS'
 
-# Quiet github3 logging
-logger = logging.getLogger('github3')
-logger.setLevel(level=logging.WARNING)
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def convert_issues_to_planning_report(md_file, repo_name, issues_map):
@@ -88,8 +83,9 @@ def main():
                         help='build label, for example B11.1 or B12.0')
 
     args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
 
-    logger.info('Working on build %s', args.build)
+    _logger.info('Working on build %s', args.build)
 
     if args.format == 'md':
         create_md_issue_report(
@@ -124,5 +120,5 @@ def main():
         rdd_metrics.create(args.github_repos)
 
     else:
-        logger.error("unsupported format %s, must be rst or md or metrics", args.format)
+        _logger.error("unsupported format %s, must be rst or md or metrics", args.format)
 

--- a/pds_github_util/plan/plan.py
+++ b/pds_github_util/plan/plan.py
@@ -1,7 +1,6 @@
 """Release Planning."""
 
 import argparse
-import github3
 import logging
 import os
 import sys
@@ -31,13 +30,8 @@ REPO_INFO = ('\n--------\n\n'
              '     - `Stable Release <{}/releases/latest>`_ \n'
              '     - `Dev Release <{}/releases>`_ \n\n')
 
-# Quiet github3 logging
-logger = logging.getLogger('github3')
-logger.setLevel(level=logging.WARNING)
-
 # Enable logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def append_to_project(proj, output):
@@ -84,21 +78,22 @@ def main():
                         required=True)
 
     args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
 
     # set output filename
-    output_fname = f'plan.rst'
+    output_fname = 'plan.rst'
 
     # get github token or throw error
     github_token = args.github_token or os.environ.get('GITHUB_TOKEN')
     if not github_token:
-        logger.error(f'github API token must be provided or set as environment'
+        _logger.error('github API token must be provided or set as environment'
                      ' variable (GITHUB_TOKEN).')
         sys.exit(1)
 
     # get zenhub token or throw error
     zenhub_token = args.github_token or os.environ.get('ZENHUB_TOKEN')
     if not zenhub_token:
-        logger.error(f'zenhub API token must be provided or set as environment'
+        _logger.error('zenhub API token must be provided or set as environment'
                      ' variable (ZENHUB_TOKEN).')
         sys.exit(1)
 
@@ -222,7 +217,7 @@ def main():
         traceback.print_exc()
         sys.exit(1)
 
-    logger.info(f'SUCCESS: Release Plan generated successfully.')
+    _logger.info('SUCCESS: Release Plan generated successfully.')
 
 if __name__ == '__main__':
     main()

--- a/pds_github_util/release/_python_version.py
+++ b/pds_github_util/release/_python_version.py
@@ -47,11 +47,11 @@ class VersioneerDetective(VersionDetective):
     '''Detective that uses Python Versioneer to tell what version we have'''
     def detect(self):
         if not sys.executable:
-            _logger.debug('🤷‍♂️ Cannot tell what my own Python executable is, so not bothering with versioneer')
+            _logger.info('🤷‍♂️ Cannot tell what my own Python executable is, so not bothering with versioneer')
             return None
         setupFile = self.findFile('setup.py')
         if not setupFile:
-            _logger.debug('🤷‍♀️ No setup.py file, so cannot call versioneer command on it')
+            _logger.info('🤷‍♀️ No setup.py file, so cannot call versioneer command on it')
             return None
         expr = re.compile(r'^Version: (.+)$')
         try:
@@ -64,7 +64,7 @@ class VersioneerDetective(VersionDetective):
                 match = expr.match(line)
                 if match: return match.group(1).strip()
         except subprocess.CalledProcessError as ex:
-            _logger.debug('🚳 Could not execute ``version`` command on ``setup.py``, rc=%d', ex.returncode)
+            _logger.info('🚳 Could not execute ``version`` command on ``setup.py``, rc=%d', ex.returncode)
         return None
 
 
@@ -82,7 +82,7 @@ class TextFileDetective(VersionDetective):
             for fn in filenames:
                 if fn.lower() == 'version.txt':
                     version_file = os.path.join(dirpath, fn)
-                    _logger.debug('🪄 Found a version.txt in %s', version_file)
+                    _logger.info('🪄 Found a version.txt in %s', version_file)
                     break
 
         return version_file
@@ -106,13 +106,13 @@ class ModuleInitDetective(VersionDetective):
             for fn in filenames:
                 if fn == '__init__.py':
                     init = os.path.join(dirpath, '__init__.py')
-                    _logger.debug('🧞‍♀️ Found a potential module init in %s', init)
+                    _logger.info('🧞‍♀️ Found a potential module init in %s', init)
                     with open(init, 'r') as inp:
                         for line in inp:
                             match = expr.match(line)
                             if match:
                                 version = match.group(1)
-                                _logger.debug('🔍 Using version «%s» from %s', version, init)
+                                _logger.info('🔍 Using version «%s» from %s', version, init)
                                 return version
         return None
 
@@ -182,14 +182,14 @@ def getVersion(workspace=None):
     # Figure out where to work
     gh = os.getenv('GITHUB_WORKSPACE')
     workspace = os.path.abspath(workspace if workspace else gh if gh else os.getcwd())
-    _logger.debug('👣 The computed path is %s', workspace)
+    _logger.info('👣 The computed path is %s', workspace)
 
     # Try each detective
     versions = set()
     for detectiveClass in _detectives:
         detective = detectiveClass(workspace)
         version = detective.detect()
-        _logger.debug('🔍 Detected version using %s is %r', detectiveClass.__name__, version)
+        _logger.info('🔍 Detected version using %s is %r', detectiveClass.__name__, version)
         if version:
             # Validate it
             try:
@@ -208,7 +208,7 @@ def getVersion(workspace=None):
     versions = list(versions)
     versions.sort(key=len)
     version = versions[0]
-    _logger.debug('🏁 High confidence version is %s', version)
+    _logger.info('🏁 High confidence version is %s', version)
     return version
 
 

--- a/pds_github_util/release/_python_version.py
+++ b/pds_github_util/release/_python_version.py
@@ -90,7 +90,7 @@ class TextFileDetective(VersionDetective):
     def detect(self):
         version_file = self.locate_file(self.workspace)
         if version_file is not None:
-            with open(versionFile, 'r') as inp:
+            with open(version_file, 'r') as inp:
                 return inp.read().strip()
         else:
             return None

--- a/pds_github_util/release/_python_version.py
+++ b/pds_github_util/release/_python_version.py
@@ -47,11 +47,11 @@ class VersioneerDetective(VersionDetective):
     '''Detective that uses Python Versioneer to tell what version we have'''
     def detect(self):
         if not sys.executable:
-            _logger.info('🤷‍♂️ Cannot tell what my own Python executable is, so not bothering with versioneer')
+            _logger.debug('🤷‍♂️ Cannot tell what my own Python executable is, so not bothering with versioneer')
             return None
         setupFile = self.findFile('setup.py')
         if not setupFile:
-            _logger.info('🤷‍♀️ No setup.py file, so cannot call versioneer command on it')
+            _logger.debug('🤷‍♀️ No setup.py file, so cannot call versioneer command on it')
             return None
         expr = re.compile(r'^Version: (.+)$')
         try:
@@ -64,7 +64,7 @@ class VersioneerDetective(VersionDetective):
                 match = expr.match(line)
                 if match: return match.group(1).strip()
         except subprocess.CalledProcessError as ex:
-            _logger.info('🚳 Could not execute ``version`` command on ``setup.py``, rc=%d', ex.returncode)
+            _logger.debug('🚳 Could not execute ``version`` command on ``setup.py``, rc=%d', ex.returncode)
         return None
 
 
@@ -82,7 +82,7 @@ class TextFileDetective(VersionDetective):
             for fn in filenames:
                 if fn.lower() == 'version.txt':
                     version_file = os.path.join(dirpath, fn)
-                    _logger.info('🪄 Found a version.txt in %s', version_file)
+                    _logger.debug('🪄 Found a version.txt in %s', version_file)
                     break
 
         return version_file
@@ -106,13 +106,13 @@ class ModuleInitDetective(VersionDetective):
             for fn in filenames:
                 if fn == '__init__.py':
                     init = os.path.join(dirpath, '__init__.py')
-                    _logger.info('🧞‍♀️ Found a potential module init in %s', init)
+                    _logger.debug('🧞‍♀️ Found a potential module init in %s', init)
                     with open(init, 'r') as inp:
                         for line in inp:
                             match = expr.match(line)
                             if match:
                                 version = match.group(1)
-                                _logger.info('🔍 Using version «%s» from %s', version, init)
+                                _logger.debug('🔍 Using version «%s» from %s', version, init)
                                 return version
         return None
 
@@ -182,14 +182,14 @@ def getVersion(workspace=None):
     # Figure out where to work
     gh = os.getenv('GITHUB_WORKSPACE')
     workspace = os.path.abspath(workspace if workspace else gh if gh else os.getcwd())
-    _logger.info('👣 The computed path is %s', workspace)
+    _logger.debug('👣 The computed path is %s', workspace)
 
     # Try each detective
     versions = set()
     for detectiveClass in _detectives:
         detective = detectiveClass(workspace)
         version = detective.detect()
-        _logger.info('🔍 Detected version using %s is %r', detectiveClass.__name__, version)
+        _logger.debug('🔍 Detected version using %s is %r', detectiveClass.__name__, version)
         if version:
             # Validate it
             try:
@@ -208,7 +208,7 @@ def getVersion(workspace=None):
     versions = list(versions)
     versions.sort(key=len)
     version = versions[0]
-    _logger.info('🏁 High confidence version is %s', version)
+    _logger.debug('🏁 High confidence version is %s', version)
     return version
 
 

--- a/pds_github_util/release/python_release.py
+++ b/pds_github_util/release/python_release.py
@@ -1,15 +1,10 @@
 import os
-import re
 import logging
 import glob
-from pathlib import Path
 from pds_github_util.release.release import release_publication
 from ._python_version import getVersion
 
-# 🧐 FYI, logging config should once happen on exec; calling `basicConfig` at the top of
-# every module resets any configuration the user may have set up:
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 SNAPSHOT_TAG_SUFFIX = "-dev"
 
@@ -23,17 +18,13 @@ def python_upload_assets(repo_name, tag_name, release):
           Upload packages produced by python setup.py
 
     """
-    package_pattern = os.path.join(os.environ.get('GITHUB_WORKSPACE'),
-                                        'dist',
-                                        '*')
+    package_pattern = os.path.join(os.environ.get('GITHUB_WORKSPACE'), 'dist', '*')
     packages = glob.glob(package_pattern)
     for package in packages:
         with open(package, 'rb') as f_asset:
             asset_filename = os.path.basename(package)
-            logger.info(f"Upload asset file {asset_filename}")
-            release.upload_asset('application/zip',
-                                 asset_filename,
-                                 f_asset)
+            _logger.info(f"Upload asset file {asset_filename}")
+            release.upload_asset('application/zip', asset_filename, f_asset)
 
 
 def main():

--- a/pds_github_util/release/release.py
+++ b/pds_github_util/release/release.py
@@ -84,6 +84,7 @@ def release_publication(suffix, get_version, upload_assets, prefix='v'):
                         help='path of workspace. defaults to current working directory if this or GITHUB_WORKSPACE not specified')
     parser.add_argument('--snapshot', action="store_true", help="Mark release as a SNAPSHOT release.")
     args, unknown = parser.parse_known_args()
+    print(f'🪵 Setting log level to {args.loglevel}, debug happens to be {logging.DEBUG}', file=sys.stderr)
     logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
 
     # read organization and repository name

--- a/pds_github_util/release/release.py
+++ b/pds_github_util/release/release.py
@@ -7,8 +7,7 @@ import sys
 from pds_github_util.utils import addStandardArguments
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets):
@@ -16,7 +15,7 @@ def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets
     
     Push the assets created in target directory.
     """
-    logger.info("create new release")
+    _logger.info("create new release")
 
     try:
         our_branch = repo.branch(branch_name)
@@ -29,18 +28,18 @@ def create_release(repo, repo_name, branch_name, tag_name, tagger, upload_assets
         # create the release
         release = repo.create_release(tag_name, target_commitish=branch_name, name=repo_name + " " + tag_name, prerelease=False)
 
-        logger.info("upload assets")
+        _logger.info("upload assets")
         upload_assets(repo_name, tag_name, release)
 
     except github3.GitHubError as error:
-        logger.error(error.errors)
+        _logger.error(error.errors)
 
 
 def delete_snapshot_releases(_repo, suffix):
     """
         Delete all pre-existing snapshot releases
     """
-    logger.info("delete previous releases")
+    _logger.info("delete previous releases")
     for release in _repo.releases():
         if release.tag_name.endswith(suffix):
             release.delete()
@@ -51,13 +50,12 @@ def create_snapshot_release(repo, repo_name, branch_name, tag_name, tagger, uplo
     Create a tag and new release from the latest commit on branch_name.
     Push the assets created in target directory.
     """
-    logger.info("create new snapshot release")
-
+    _logger.info("create new snapshot release")
 
     try:
         our_branch = repo.branch(branch_name)
         repo.create_tag(tag_name,
-                        f'SNAPSHOT release',
+                        'SNAPSHOT release',
                         our_branch.commit.sha,
                         "commit",
                         tagger)
@@ -65,10 +63,10 @@ def create_snapshot_release(repo, repo_name, branch_name, tag_name, tagger, uplo
         # create the release
         release = repo.create_release(tag_name, target_commitish=branch_name, name=repo_name + " " + tag_name, prerelease=True)
 
-        logger.info("upload assets")
+        _logger.info("upload assets")
         upload_assets(repo_name, tag_name, release)
 
-    except GitHubError as error:
+    except github3.exceptions.GitHubError as error:  # 💢
         print(error.errors)
 
 
@@ -86,11 +84,12 @@ def release_publication(suffix, get_version, upload_assets, prefix='v'):
                         help='path of workspace. defaults to current working directory if this or GITHUB_WORKSPACE not specified')
     parser.add_argument('--snapshot', action="store_true", help="Mark release as a SNAPSHOT release.")
     args, unknown = parser.parse_known_args()
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
 
     # read organization and repository name
     repo_full_name = args.repo_name or os.environ.get('GITHUB_REPOSITORY')
     if not repo_full_name:
-        logger.error(f'Github repository must be provided or set as environment variable (GITHUB_REPOSITORY).')
+        _logger.error('Github repository must be provided or set as environment variable (GITHUB_REPOSITORY).')
         sys.exit(1)
 
     workspace = args.workspace or os.environ.get('GITHUB_WORKSPACE')
@@ -100,7 +99,7 @@ def release_publication(suffix, get_version, upload_assets, prefix='v'):
 
     token = args.token or os.environ.get('GITHUB_TOKEN')
     if not token:
-        logger.error(f'Github token must be provided or set as environment variable (GITHUB_TOKEN).')
+        _logger.error('Github token must be provided or set as environment variable (GITHUB_TOKEN).')
 
     repo_full_name_array = repo_full_name.split("/")
     org = repo_full_name_array[0]

--- a/pds_github_util/requirements/generate_requirements.py
+++ b/pds_github_util/requirements/generate_requirements.py
@@ -1,11 +1,12 @@
 import argparse
 import logging
+import sys
 from pds_github_util.requirements.requirements import Requirements, NoAppropriateVersionFoundException
 from pds_github_util.utils import addStandardArguments
 
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
+
 
 def main():
     parser = argparse.ArgumentParser(description='Create a requirement report')
@@ -15,9 +16,9 @@ def main():
     parser.add_argument('--repository', dest='repository',
                         help='github repository name')
     parser.add_argument('--dev', dest='dev',
-                        nargs = '?',
-                        const = True, default = False,
-                        help = "Generate requirements with impacts related to latest dev/snapshot version")
+                        nargs='?',
+                        const=True, default=False,
+                        help="Generate requirements with impacts related to latest dev/snapshot version")
     parser.add_argument('--output', dest='output',
                         help='directory where version/REQUIREMENTS.md file is created')
     parser.add_argument('--format', dest='format', default='md',
@@ -25,16 +26,16 @@ def main():
     parser.add_argument('--token', dest='token',
                         help='github personal access token')
     args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
 
     try:
         requirements = Requirements(args.organization, args.repository, token=args.token, dev=args.dev)
         requirement_file = requirements.write_requirements(root_dir=args.output, format=args.format)
         print(requirement_file)
     except NoAppropriateVersionFoundException as e:
-        print('')
-        logger.error(e)
-        exit(0) # we don't want the github action to fail after that
-
+        print('')  # Write just a newline to stdout I guess
+        _logger.error(e)
+        sys.exit(0)  # we don't want the github action to fail after that
 
 
 if __name__ == "__main__":

--- a/pds_github_util/requirements/requirements.py
+++ b/pds_github_util/requirements/requirements.py
@@ -9,7 +9,6 @@ from pds_github_util.tags.tags import Tags
 
 from pds_github_util.html.md_to_html import md_to_html
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/pds_github_util/utils/RstClothReferenceable.py
+++ b/pds_github_util/utils/RstClothReferenceable.py
@@ -2,8 +2,8 @@ import os
 import logging
 from rstcloth import RstCloth
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 def _indent(content, indent):
     """

--- a/pds_github_util/utils/argparse.py
+++ b/pds_github_util/utils/argparse.py
@@ -4,6 +4,7 @@
 
 from argparse import ArgumentParser
 from pds_github_util import __version__
+import logging
 
 
 def addStandardArguments(parser: ArgumentParser):
@@ -14,3 +15,14 @@ def addStandardArguments(parser: ArgumentParser):
     '''
 
     parser.add_argument('--version', action='version', version=__version__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '-d', '--debug',
+        action='store_const', const=logging.DEBUG, default=logging.INFO, dest='loglevel',
+        help='Log copious debugging messages suitable for developers'
+    )
+    group.add_argument(
+        '-q', '--quiet',
+        action='store_const', const=logging.WARNING, dest='loglevel',
+        help="Don't log anything except warnings and critically-important messages"
+    )

--- a/pds_github_util/utils/githubConnection.py
+++ b/pds_github_util/utils/githubConnection.py
@@ -4,12 +4,9 @@ import sys
 
 from github3 import login
 
-# Quiet github3 logging
-logger = logging.getLogger('github3')
-logger.setLevel(level=logging.WARNING)
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
+
 
 class GithubConnection():
 
@@ -20,7 +17,7 @@ class GithubConnection():
         if not cls.gh:
             token = token or os.environ.get('GITHUB_TOKEN')
             if not token:
-                logger.error(f'Github token must be provided or set as environment variable (GITHUB_TOKEN).')
+                _logger.error('Github token must be provided or set as environment variable (GITHUB_TOKEN).')
                 sys.exit(1)
 
             cls.gh = login(token=token)

--- a/pds_github_util/utils/pds4_validate.py
+++ b/pds_github_util/utils/pds4_validate.py
@@ -14,7 +14,6 @@ import traceback
 
 from datetime import datetime
 from subprocess import Popen, CalledProcessError, PIPE, STDOUT
-from zipfile import ZipFile
 
 from pds_github_util.tags.tags import Tags
 from pds_github_util.assets.assets import download_asset, unzip_asset
@@ -30,12 +29,7 @@ PDS_SCHEMA_URL = 'https://pds.nasa.gov/pds4/pds/v1/'
 PDS_DEV_SCHEMA_URL = 'https://pds.nasa.gov/datastandards/schema/develop/pds/'
 DOWNLOAD_PATH = '/tmp'
 
-# Quiet github3 logging
-logger = logging.getLogger('github3')
-logger.setLevel(level=logging.WARNING)
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def get_latest_release(token, dev=False):
@@ -72,13 +66,13 @@ def download_schemas(download_path, pds4_version, dev_release=False):
 
         fname = 'PDS4_PDS_' + pds4_version_short
         for suffix in ['.xsd', '.sch']:
-            logger.info(f'Downloading {base_url + fname + suffix}')
+            _logger.info(f'Downloading {base_url + fname + suffix}')
             r = requests.get(base_url + fname + suffix, allow_redirects=True)
             with open(os.path.join(download_path, fname + suffix), 'wb') as f:
                 f.write(r.content)
 
     except Exception as e:
-        logger.error('Failure attempting to download schemas.')
+        _logger.error('Failure attempting to download schemas.')
         raise e
         traceback.print_exc
         sys.exit(1)
@@ -121,11 +115,12 @@ def main():
                         action='store_true', default=False)
 
     args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s %(message)s")
 
     token = args.token or os.environ.get('GITHUB_TOKEN')
 
     if not token:
-        logger.error(f'Github token must be provided or set as environment variable (GITHUB_TOKEN).')
+        _logger.error('Github token must be provided or set as environment variable (GITHUB_TOKEN).')
         sys.exit(1)
 
     try:
@@ -163,20 +158,20 @@ def main():
         validate_args.append('-t')
         validate_args.extend(glob.glob(args.datapath, recursive=True))
 
-
         pkg = download_asset(get_latest_release(token), args.deploy_dir, startswith="validate", file_extension='.zip')
         sw_dir = unzip_asset(pkg, args.deploy_dir)
 
         exec_validate(os.path.join(sw_dir, 'bin', 'validate'), validate_args, log_path=args.output_log_path)
     except CalledProcessError:
         if not args.failure_expected:
-            logger.error(f'FAILED: Validate failed unexpectedly. See output logs.')
+            _logger.error('FAILED: Validate failed unexpectedly. See output logs.')
             sys.exit(1)
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
         sys.exit(1)
 
-    logger.info(f'SUCCESS: Validation complete.')
+    _logger.info('SUCCESS: Validation complete.')
+
 
 if __name__ == '__main__':
     main()

--- a/pds_github_util/zenhub/zenhub.py
+++ b/pds_github_util/zenhub/zenhub.py
@@ -1,12 +1,10 @@
 """ZenhubWrapper."""
 
-import github3
 import logging
 import time
 import requests
 
 # Enable logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 ZENHUB_URL = 'https://api.zenhub.com{}?access_token={}'

--- a/tests/branches/test_git-actions.py
+++ b/tests/branches/test_git-actions.py
@@ -4,8 +4,9 @@ import logging
 from pds_github_util.branches.git_actions import ping_repo_branch
 from pds_github_util.utils.tokens import GITHUB_TOKEN
 
-logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
+
 
 class MyTestCase(unittest.TestCase):
     def test_ping_branch(self):

--- a/tests/corral/test_summary.py
+++ b/tests/corral/test_summary.py
@@ -5,8 +5,9 @@ from pds_github_util.corral.herd import Herd
 from pds_github_util.gh_pages.summary import write_build_summary
 from pds_github_util.utils.tokens import GITHUB_TOKEN
 
-logging.basicConfig(level=logging.INFO)
+
 logger = logging.getLogger(__name__)
+
 
 class MyTestCase(unittest.TestCase):
 

--- a/tests/releases/test_maven_get_version.py
+++ b/tests/releases/test_maven_get_version.py
@@ -3,7 +3,6 @@ import os
 import logging
 from pds_github_util.release.maven_release import maven_get_version
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/tests/releases/test_python_get_version.py
+++ b/tests/releases/test_python_get_version.py
@@ -3,7 +3,6 @@ import os
 import logging
 from pds_github_util.release.python_release import python_get_version
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/tests/requirements/test_requirements.py
+++ b/tests/requirements/test_requirements.py
@@ -4,8 +4,9 @@ import logging
 from pds_github_util.requirements.requirements import Requirements, NoAppropriateVersionFoundException
 from pds_github_util.utils.tokens import GITHUB_TOKEN
 
-logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
+
 
 class MyTestCase(unittest.TestCase):
     def test_get_requirements(self):

--- a/tests/tags/test_tags.py
+++ b/tests/tags/test_tags.py
@@ -1,12 +1,7 @@
 import unittest
-import os
-import logging
 from datetime import datetime
 from pds_github_util.tags.tags import Tags
 from pds_github_util.utils.tokens import GITHUB_TOKEN
-
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
 
 
 class MyTestCase(unittest.TestCase):


### PR DESCRIPTION
Logging throughout pds-github-util was a mess: virtually every module called `basicConfig` which overrides whatever configuration the user may have set up via logging configuration files. It also messes up logging whenever any of these modules are imported as frameworks into other systems. This commit gets rid of the helter-skelter calls to `basicConfig` and adds a simple log setup to each `main` entrypoint only, which is set by two config options, `-d` for debugging messages (log level = DEBUG) and `-q` for quiet (log level = WARNING).

