### PR TITLE
Drop github-actions-base repository dispatches

### DIFF
--- a/.github/workflows/squaredown-stable.yaml
+++ b/.github/workflows/squaredown-stable.yaml
@@ -68,16 +68,6 @@ jobs:
                     # Should really use PyPI's API token stuff here
                     user: ${{secrets.PYPI_USERNAME}}
                     password: ${{secrets.PYPI_PASSWORD}}
-            -
-                 # Send a respository dispatch to pds-actions-base to trigger
-                 # a fresh build since it depends on pds-github-util
-                 name: Trigger github-actions-base build
-                 uses: peter-evans/repository-dispatch@v1
-                 with:
-                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
-                     repository: NASA-PDS/github-actions-base
-                     event-type: pds-github-util-built
-
 ...
 
 # -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -72,14 +72,5 @@ jobs:
                     pypi_username: ${{secrets.PYPI_USERNAME}}
                     pypi_password: ${{secrets.PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
-            -
-                 # Send a respository dispatch to pds-actions-base to trigger
-                 # a fresh build since it depends on pds-github-util
-                 name: Trigger github-actions-base build
-                 uses: peter-evans/repository-dispatch@v1
-                 with:
-                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
-                     repository: NASA-PDS/github-actions-base
-                     event-type: pds-github-util-built
 
 ...


### PR DESCRIPTION
Drop repo dispatches to github-actions-base from stable builds. These
are no longer necessary due to the removal of pds-github-util as a
dependency in the Docker build in
nasa-pds-engineering-node/github-actions-base#1


